### PR TITLE
include file download directory path in file name in order to rename it

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const SftpToS3 = {
         })
         .then((files) => {
           files.map((file) => {
-            sftp.rename(file.name, config.completedDir + file.name);
+            sftp.rename(config.fileDownloadDir + file.name, config.completedDir + file.name);
           })
           console.log("upload finished")
           sftp.end()


### PR DESCRIPTION
## Description
This uses the file download directory in order to find files when renaming them. Without this, unless your download dir is `/` as in the example, the file won't be found.

## Motivation and Context
On my FTP server, I'm downloading from a directory that is not the root directory, so renaming requires the full file path in order for the file to be found. 

## How Has This Been Tested?
I have tested this using my forked repository.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
